### PR TITLE
pom.xml - fix that lets it compile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>0.11.4</version>
+			<version>1.18.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
pom.xml specifies an old version of Lombok as a dependency, and, because of this, it won't compile. Changing the version to the current one in line 101 fixes that.